### PR TITLE
Allow the build date/time to be overridden by BUILD_DATE

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,9 +2,12 @@ AUTOMAKE_OPTIONS = foreign
 
 bin_PROGRAMS = ircd
 
+BUILD_DATE ?= $(shell LANG=C date '+%b %e %Y %H:%M:%S')
+
 AM_YFLAGS = -d
 
 AM_CPPFLAGS = $(LTDLINCL) -I$(top_srcdir)/include
+ircd_CFLAGS = -DBUILD_DATE="\"$(BUILD_DATE)\""
 ircd_LDFLAGS = -export-dynamic
 ircd_LDADD = $(LIBLTDL)
 ircd_DEPENDENCIES = $(LTDLDEPS)

--- a/src/user.c
+++ b/src/user.c
@@ -50,6 +50,10 @@
 #include "watch.h"
 #include "isupport.h"
 
+#ifndef BUILD_DATE
+#define BUILD_DATE __DATE__ " at " __TIME__
+#endif
+
 static char umode_buffer[IRCD_BUFSIZE];
 
 const struct user_modes *umode_map[256];
@@ -263,11 +267,7 @@ introduce_client(struct Client *source_p)
 static void
 user_welcome(struct Client *source_p)
 {
-#if defined(__TIME__) && defined(__DATE__)
-  static const char built_date[] = __DATE__ " at " __TIME__;
-#else
-  static const char built_date[] = "unknown";
-#endif
+static const char built_date[] = BUILD_DATE;
 
 #ifdef HAVE_LIBCRYPTO
   if (HasFlag(source_p, FLAGS_SSL))


### PR DESCRIPTION
Including the current date/time in the build means that it cannot be
reproducible. Instead, BUILD_DATE can be set to a value from the source
(in the Debian project, this will be the latest changelog date).

See https://wiki.debian.org/ReproducibleBuilds/TimestampsFromCPPMacros
for more information.
