### PR TITLE
Repair for possible stack address leakage

### DIFF
--- a/modules/core/m_join.c
+++ b/modules/core/m_join.c
@@ -426,6 +426,8 @@ remove_a_mode(struct Channel *chptr, struct Client *source_p, int mask, const ch
                          (IsHidden(source_p) || ConfigServerHide.hide_servers) ?
                          me.name : source_p->name, chptr->name, lmodebuf, sendbuf);
   }
+  
+  mbuf = NULL;
 }
 
 static struct Message join_msgtab =

--- a/modules/core/m_sjoin.c
+++ b/modules/core/m_sjoin.c
@@ -698,6 +698,8 @@ remove_a_mode(struct Channel *chptr, struct Client *source_p,
                          me.name : source_p->name,
                          chptr->name, lmodebuf, sendbuf);
   }
+  
+  mbuf = NULL;
 }
 
 /* remove_ban_list()


### PR DESCRIPTION
Hi all,
There is a possible stack address leakage found by Qihoo360 CodeSafe Team.
Details as bellow:

in function remove_a_mode(), global pointer mbuf is set to point the local memory (char array lmodebuf).
after the function is call, the memory of char array lmodebuf will be destroyed.
set the global pointer to NULL, in case that the pointer could be ok to continue be used.

Cheers
Qihoo360 CodeSafe Team