### PR TITLE
Declare event_base as extern to fix build failure with GCC 10

### DIFF
--- a/include/event.h
+++ b/include/event.h
@@ -37,7 +37,7 @@ struct event_base
   } time;
 };
 
-struct event_base *event_base;
+extern struct event_base *event_base;
 
 struct event
 {


### PR DESCRIPTION
Without this, build fails with:

/usr/bin/ld: channel.o:./src/../include/event.h:40: multiple definition of
`event_base'; auth.o:./src/../include/event.h:40: first defined here
[...]

Note: I'm not a C programmer; I've verified this fix on Debian, but please check that this is sane before applying!

Debian bug: https://bugs.debian.org/957377