### PR TITLE
Replace ERR_NOCTCP with ERR_CANNOTSENDTOCHAN

### DIFF
--- a/include/numeric.h
+++ b/include/numeric.h
@@ -213,7 +213,6 @@ enum irc_numerics
   ERR_NONONREG             = 486,
   ERR_SECUREONLYCHAN       = 489,
   ERR_NOOPERHOST           = 491,
-  ERR_NOCTCP               = 492,
   ERR_UMODEUNKNOWNFLAG     = 501,
   ERR_USERSDONTMATCH       = 502,
   ERR_USERNOTONSERV        = 504,

--- a/src/channel.c
+++ b/src/channel.c
@@ -811,7 +811,7 @@ can_send(struct Channel *channel, struct Client *client,
 
   if (HasCMode(channel, MODE_NOCTCP))
     if (*message == '\001' && strncmp(message + 1, "ACTION ", 7))
-      return ERR_NOCTCP;
+      return ERR_CANNOTSENDTOCHAN;
 
   if (member || (member = member_find_link(client, channel)))
     if (member->flags & (CHFL_CHANOP | CHFL_HALFOP | CHFL_VOICE))

--- a/src/numeric.c
+++ b/src/numeric.c
@@ -194,7 +194,6 @@ static const char *const replies[] =
   /* 486 */  [ERR_NONONREG] = "%s :You must identify to a registered nick to private message that person",
   /* 489 */  [ERR_SECUREONLYCHAN] = "%s :Cannot join channel (+S) - TLS required",
   /* 491 */  [ERR_NOOPERHOST] = ":Only few of mere mortals may try to enter the twilight zone",
-  /* 492 */  [ERR_NOCTCP] = "%s :You cannot send CTCPs to this channel. Not sent: %s",
   /* 501 */  [ERR_UMODEUNKNOWNFLAG] = ":Unknown MODE flag",
   /* 502 */  [ERR_USERSDONTMATCH] = ":Cannot change mode for other users",
   /* 504 */  [ERR_USERNOTONSERV] = "%s :User is not on this server",


### PR DESCRIPTION
Hybrid seems to be the last IRCd to use this numeric; others already did this
switch to make it easier for clients and/or simplify their implementations:

* https://github.com/inspircd/inspircd/commit/ba31d8080f75a0147d0b380f2c51251e024f0deb
* https://github.com/solanum-ircd/solanum/commit/f30a5ee4c43ea0893b77925e1cca8f94e7e295fe
* https://github.com/unrealircd/unrealircd/commit/2eecf4f2da58798dee6962e49bff0c4f72df752c