### PR TITLE
Fix regression in list_allow_channel

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -513,9 +513,13 @@ free_list_task(struct Client *client)
 static bool
 list_allow_channel(const char *name, const struct ListTask *lt)
 {
+  dlink_node *node;
 
-  if (dlinkFindCmp(&lt->show_mask, name, match) == NULL ||
-      dlinkFindCmp(&lt->hide_mask, name, match))
+  DLINK_FOREACH(node, lt->show_mask.head)
+    if (match(node->data, name) != 0)
+      return false;
+
+  if (dlinkFindCmp(&lt->hide_mask, name, match))
     return false;
 
   return true;


### PR DESCRIPTION
The first loop checks whether all masks match, and returns false if any does not (so in particular, if there is no mask, then the channel is allowed)

The change introduced in a5401152ad2c4ffad9b10da86bbcca6f3e7b3472 makes it return false if none of them do (so in particular, if there is no mask, then the channel is not allowed)