### PR TITLE
ci: Update irctest

### DIFF
--- a/.github/workflows/irctest-ci.yml
+++ b/.github/workflows/irctest-ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: irctest
-          ref: e6d54db9ce8d916b6629c61e970b1f3f1fc2db94
+          ref: 052198c61b005c009aedd1855b070289e6904257
           repository: progval/irctest
 
       - name: configure


### PR DESCRIPTION
It includes the required configuration change to load modules (ie. #49), now that loading has to be explicit: https://github.com/progval/irctest/pull/283

#48 is not necessary for this to work

This means you can re-enable the irctest CI that started failing two days ago