### PR TITLE
Remove C comment style example, to prevent syntax error next line

### DIFF
--- a/doc/reference.ircd.conf
+++ b/doc/reference.ircd.conf
@@ -7,7 +7,7 @@
  * Supported comment styles:
  *   - Shell style:  #
  *   - C++ style:  //
- *   - C style:  /* ... */
+ *   - C style
  *
  * Including files:
  *   - To include files, use either of the following directives:


### PR DESCRIPTION
The example `/* ... */` in line 10 closes the comment, leading to an error in line 11, when loading the configuration file.

I am aware that this configuration file is just a reference and the irc server admin is supposed to write his own configuration anyways, so I'm not sure if this should even be fixed.