### PR TITLE
Fix segfault on client connection

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -170,7 +170,8 @@ client_free(struct Client *client)
   assert(client->svstags.head == NULL);
   assert(client->svstags.tail == NULL);
 
-  io_free(client->serv->initiator_name);
+  if (client->serv)
+    io_free(client->serv->initiator_name);
   io_free(client->serv);
   io_free(client->tls_certfp);
   io_free(client->tls_cipher);


### PR DESCRIPTION
Since a07710cf5dcb8b31de050c8f23697b5feec941fc, clients can't connect anymore:

```
==1578020== Invalid read of size 8
==1578020==    at 0x11BA46: client_free (client.c:175)
==1578020==    by 0x11BA46: free_exited_clients (client.c:587)
==1578020==    by 0x115E34: io_loop (ircd.c:222)
==1578020==    by 0x115E34: main (ircd.c:519)
==1578020==  Address 0x30 is not stack'd, malloc'd or (recently) free'd
==1578020== 
==1578020== 
==1578020== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==1578020==  Access not within mapped region at address 0x30
==1578020==    at 0x11BA46: client_free (client.c:175)
==1578020==    by 0x11BA46: free_exited_clients (client.c:587)
==1578020==    by 0x115E34: io_loop (ircd.c:222)
==1578020==    by 0x115E34: main (ircd.c:519)
```