### PR TITLE
Ignore any nonpositive value for WHOWAS's max_results argument

### DIFF
--- a/src/whowas.c
+++ b/src/whowas.c
@@ -275,7 +275,7 @@ whowas_query(const char *name, int max_results, whowas_callback_t callback, void
   list_node_t *node;
   LIST_FOREACH(node, group->whowas_records.head)
   {
-    if (max_results != -1 && count >= max_results)
+    if (max_results > 0 && count >= max_results)
       break;
 
     const struct Whowas *const whowas = node->data;


### PR DESCRIPTION
This reverts an unintentional change of behavior in 9970505e06153f8e94a84ff8be2c0dfd1d71fe73 that made `WHOWAS nick 0` return `406 mynick nick :There was no such nickname` instead of actual results.

This is not a big deal as [the spec](https://modern.ircdocs.horse/#whowas-message) requires the value to be positive, but it still needlessly differs from other IRCds and previous versions of Hybrid.